### PR TITLE
Adds `phased_restart:or_start` and `restart:or_start` tasks

### DIFF
--- a/lib/mina/puma/tasks.rake
+++ b/lib/mina/puma/tasks.rake
@@ -46,10 +46,26 @@ namespace :puma do
     pumactl_command 'restart'
   end
 
+  namespace :restart do
+    desc 'Restart puma or start if not running'
+    task :or_start => :environment do
+      comment "Restart Puma ..."
+      pumactl_command 'restart', true
+    end
+  end
+
   desc 'Restart puma (phased restart)'
   task phased_restart: :environment do
     comment "Restart Puma -- phased..."
     pumactl_command 'phased-restart'
+  end
+
+  namespace :phased_restart do
+    desc 'Restart puma (phased restart) or start if not running'
+    task :or_start => :environment do
+      comment "Restart Puma -- phased..."
+      pumactl_command 'phased-restart', true
+    end
   end
 
   desc 'Restart puma (hard restart)'
@@ -65,7 +81,9 @@ namespace :puma do
     pumactl_command 'status'
   end
 
-  def pumactl_command(command)
+  def pumactl_command(command, or_start = false)
+    puma_port_option = "-p #{fetch(:puma_port)}" if set?(:puma_port)
+
     cmd =  %{
       if [ -e "#{fetch(:pumactl_socket)}" ]; then
         if [ -e "#{fetch(:puma_config)}" ]; then
@@ -74,7 +92,14 @@ namespace :puma do
           cd #{fetch(:puma_root_path)} && #{fetch(:pumactl_cmd)} -S #{fetch(:puma_state)} -C "unix://#{fetch(:pumactl_socket)}" --pidfile #{fetch(:puma_pid)} #{command}
         fi
       else
-        echo 'Puma is not running!';
+        if [[ "#{or_start}" == "true"* ]];then
+          echo 'Puma is not running, starting!';
+          if [ -e "#{fetch(:puma_config)}" ]; then
+            cd #{fetch(:puma_root_path)} && #{fetch(:puma_cmd)} -q -d -e #{fetch(:puma_env)} -C #{fetch(:puma_config)}
+          else
+            cd #{fetch(:puma_root_path)} && #{fetch(:puma_cmd)} -q -d -e #{fetch(:puma_env)} -b "unix://#{fetch(:puma_socket)}" #{puma_port_option} -S #{fetch(:puma_state)} --pidfile #{fetch(:puma_pid)} --control 'unix://#{fetch(:pumactl_socket)}'
+          fi
+        fi
       fi
     }
     command cmd


### PR DESCRIPTION
## rationale

When I deploy app with `mina-puma`, I want to be able to use one command to restart (or start app if needed). With tasks available right now, it's not possible, so to check whether app is running I would need to bring extra stuff, that is already in `mina-puma` (eg. `:pumactl_socket` ), to my `deploy.rb`.  


## changes done
`pumactl_command ` was extended to accept one more parameter `or_start`, which defaults to false, so no changes needs to be done to current code. When`or_start` is set to `true`, app will be started when not running.

New tasks `restart:or_start` and `phased_restart:or_start` were added utilising this functionality.

Please let me know if that's fine, or you can see a better way to do it. Then I can update README and so on. 