### PR TITLE
Fix puma start due to SSH -tt

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ OR you can set other directories by setting follow variables:
 * `puma_socket` - puma socket file, default is `shared/tmp/sockets/puma.sock`
 * `puma_pid` - puma pid file, default `shared/tmp/pids/puma.pid`
 * `puma_state` - puma state file, default `shared/tmp/sockets/puma.state`
+* `puma_stdout` - puma redirect path for stdout, default `shared/log/puma.log`
+* `puma_stderr` - puma redirect path for stderr, default `shared/log/puma.log`
 * `pumactl_socket` - pumactl socket file, default `shared/tmp/sockets/pumactl.sock`
 * `puma_root_path` - puma command execute root path, default `current`
 

--- a/lib/mina/puma/tasks.rake
+++ b/lib/mina/puma/tasks.rake
@@ -10,6 +10,8 @@ namespace :puma do
   set :puma_socket,    -> { "#{fetch(:shared_path)}/tmp/sockets/puma.sock" }
   set :puma_state,     -> { "#{fetch(:shared_path)}/tmp/sockets/puma.state" }
   set :puma_pid,       -> { "#{fetch(:shared_path)}/tmp/pids/puma.pid" }
+  set :puma_stdout,    -> { "#{fetch(:shared_path)}/log/puma.log" }
+  set :puma_stderr,    -> { "#{fetch(:shared_path)}/log/puma.log" }
   set :puma_cmd,       -> { "#{fetch(:bundle_prefix)} puma" }
   set :pumactl_cmd,    -> { "#{fetch(:bundle_prefix)} pumactl" }
   set :pumactl_socket, -> { "#{fetch(:shared_path)}/tmp/sockets/pumactl.sock" }
@@ -27,7 +29,7 @@ namespace :puma do
         if [ -e "#{fetch(:puma_config)}" ]; then
           cd #{fetch(:puma_root_path)} && #{fetch(:puma_cmd)} -q -d -e #{fetch(:puma_env)} -C #{fetch(:puma_config)}
         else
-          cd #{fetch(:puma_root_path)} && #{fetch(:puma_cmd)} -q -d -e #{fetch(:puma_env)} -b "unix://#{fetch(:puma_socket)}" #{puma_port_option} -S #{fetch(:puma_state)} --pidfile #{fetch(:puma_pid)} --control 'unix://#{fetch(:pumactl_socket)}'
+          cd #{fetch(:puma_root_path)} && #{fetch(:puma_cmd)} -q -d -e #{fetch(:puma_env)} -b "unix://#{fetch(:puma_socket)}" #{puma_port_option} -S #{fetch(:puma_state)} --pidfile #{fetch(:puma_pid)} --control 'unix://#{fetch(:pumactl_socket)}' --redirect-stdout "#{fetch(:puma_stdout)}" --redirect-stderr "#{fetch(:puma_stderr)}"
         fi
       fi
     ]


### PR DESCRIPTION
I had the problem of unable to start puma via mina, even though I can start puma by running the script generated by mina on my own SSH console.

Until I found this issue: https://github.com/puma/puma/issues/1276

Seems that it can only be fixed here.
Feel free to comment on whether there are options.